### PR TITLE
Added Persist SeekBar Setting

### DIFF
--- a/720p/SkinSettings.xml
+++ b/720p/SkinSettings.xml
@@ -196,6 +196,12 @@
 						<onclick>Skin.ToggleSetting(ShowVideoInfo)</onclick>
 						<selected>Skin.HasSetting(ShowVideoInfo)</selected>
 					</control>
+					<control type="radiobutton" id="8109">
+	          <include>SettingsRadioButton</include>
+						<label>31421</label>
+						<onclick>Skin.ToggleSetting(PersistSeekBar)</onclick>
+						<selected>Skin.HasSetting(PersistSeekBar)</selected>
+					</control>
 				</control>
 				
 				<!-- ================= -->

--- a/720p/VideoFullScreen.xml
+++ b/720p/VideoFullScreen.xml
@@ -661,7 +661,7 @@
 				<effect type="zoom" time="350" center="640,360" start="100" end="150" tween="cubic" easing="in"/>
 				<effect type="fade" time="350" start="100" easing="in" end="0"/>
 			</animation>
-			<animation type="Conditional" condition="Player.Paused + ![Player.Caching | Player.Seeking | Player.DisplayAfterSeek | Player.SeekOffset | Player.Forwarding | Player.Rewinding | Player.ShowInfo]">
+			<animation type="Conditional" condition="Player.Paused + ![Player.Caching | Player.Seeking | Player.DisplayAfterSeek | Player.SeekOffset | Player.Forwarding | Player.Rewinding | Player.ShowInfo] + !Skin.HasSetting(PersistSeekBar)">
 				<effect type="zoom" time="350" delay="13000" center="640,360" start="100" end="0" tween="cubic" easing="in"/>
 				<effect type="fade" time="350" delay="13000" start="100" easing="in" end="0"/>
 			</animation>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -911,7 +911,11 @@ msgctxt "#31420"
 msgid "Configure Skin Settings"
 msgstr ""
 
-#empty strings from id 31421 to 31430
+msgctxt "#31421"
+msgid "Persistent Seek Bar"
+msgstr ""
+
+#empty strings from id 31422 to 31430
 
 #Help Messages
 msgctxt "#31431"


### PR DESCRIPTION
Currently the Pause/SeekBar dialog disappears after 13 seconds however
when resuming the fade-out animation still occurs and looks out of
place.

This adds an option to keep the pause/seekbar osd up indefinitely.
